### PR TITLE
Fix text color in dark mode

### DIFF
--- a/Boxer/BXThemes.m
+++ b/Boxer/BXThemes.m
@@ -610,7 +610,7 @@
 
 - (NSColor *) textColor
 {
-    return [NSColor blackColor];
+    return [NSColor labelColor];
 }
 
 - (NSShadow *) dropShadow

--- a/Boxer/Inspector Panel/BXJoystickItem.m
+++ b/Boxer/Inspector Panel/BXJoystickItem.m
@@ -39,7 +39,7 @@
     else
     {
         self.titleLabel.themeKey = @"BXInspectorListTheme";
-        self.descriptionLabel.themeKey = @"BXInspectorListHelpTextTheme";
+        self.descriptionLabel.themeKey = @"BXInspectorListTheme";
         self.icon.themeKey = @"BXInspectorListTheme";
     }
 }

--- a/Resources/Base.lproj/Inspector.xib
+++ b/Resources/Base.lproj/Inspector.xib
@@ -52,7 +52,7 @@
                                                         <outlet property="nextKeyView" destination="2155" id="2165"/>
                                                     </connections>
                                                 </imageView>
-                                                <textField verticalHuggingPriority="750" id="2149" customClass="BXIndentedHelpTextLabel">
+                                                <textField verticalHuggingPriority="750" id="2149">
                                                     <rect key="frame" x="20" y="212" width="256" height="29"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="center" id="2150">
@@ -70,7 +70,7 @@ to change this game’s icon.</string>
                                                         <rect key="frame" x="1" y="1" width="296" height="132"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <subviews>
-                                                            <textField verticalHuggingPriority="750" id="2180" customClass="BXIndentedHelpTextLabel">
+                                                            <textField verticalHuggingPriority="750" id="2180">
                                                                 <rect key="frame" x="20" y="15" width="256" height="29"/>
                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                 <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" id="2181">
@@ -184,7 +184,7 @@ to the DOS prompt instead.</string>
                                             <rect key="frame" x="0.0" y="0.0" width="296" height="432"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                             <subviews>
-                                                <textField verticalHuggingPriority="750" id="2225" customClass="BXIndentedHelpTextLabel">
+                                                <textField verticalHuggingPriority="750" id="2225">
                                                     <rect key="frame" x="20" y="139" width="256" height="28"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" id="2226">
@@ -226,7 +226,7 @@ sound or animation are stuttering.</string>
                                                                     <outlet property="nextKeyView" destination="2044" id="2286"/>
                                                                 </connections>
                                                             </button>
-                                                            <textField verticalHuggingPriority="750" id="2031" customClass="BXIndentedHelpTextLabel">
+                                                            <textField verticalHuggingPriority="750" id="2031">
                                                                 <rect key="frame" x="20" y="15" width="256" height="28"/>
                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                 <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" title="Turn off optimized emulation if the game crashes or behaves unreliably." id="2034">
@@ -464,7 +464,7 @@ sound or animation are stuttering.</string>
                                                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
                                                 </textField>
-                                                <textField verticalHuggingPriority="750" id="1969" customClass="BXIndentedHelpTextLabel">
+                                                <textField verticalHuggingPriority="750" id="1969">
                                                     <rect key="frame" x="21" y="300" width="256" height="29"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" id="1970">
@@ -475,7 +475,7 @@ the mouse pointer is locked to the window.</string>
                                                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
                                                 </textField>
-                                                <textField verticalHuggingPriority="750" id="1996" customClass="BXIndentedHelpTextLabel">
+                                                <textField verticalHuggingPriority="750" id="1996">
                                                     <rect key="frame" x="20" y="68" width="256" height="29"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" id="1997">
@@ -518,7 +518,7 @@ with the game’s own keyboard controls.</string>
                                                                     <outlet property="nextKeyView" destination="1998" id="2010"/>
                                                                 </connections>
                                                             </button>
-                                                            <textField verticalHuggingPriority="750" id="1985" customClass="BXIndentedHelpTextLabel">
+                                                            <textField verticalHuggingPriority="750" id="1985">
                                                                 <rect key="frame" x="20" y="15" width="264" height="28"/>
                                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                 <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" title="Lets the OS X mouse pointer interact with the DOS window even when the pointer is unlocked." id="1986">
@@ -600,7 +600,7 @@ with the game’s own keyboard controls.</string>
                                                         <action selector="showDrivesPanelHelp:" target="-2" id="1477"/>
                                                     </connections>
                                                 </button>
-                                                <textField verticalHuggingPriority="750" id="2189" customClass="BXIndentedHelpTextLabel">
+                                                <textField verticalHuggingPriority="750" id="2189">
                                                     <rect key="frame" x="20" y="379" width="256" height="29"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="center" id="2190">
@@ -701,7 +701,7 @@ to add them as DOS drives.</string>
                                                         <imageView id="1689">
                                                             <rect key="frame" x="20" y="227" width="256" height="160"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                            <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyUpOrDown" image="GamepadTemplate" id="1690" customClass="BXIndentedImageCell"/>
+                                                            <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyUpOrDown" image="GamepadTemplate" id="1690"/>
                                                         </imageView>
                                                         <button horizontalHuggingPriority="750" verticalHuggingPriority="750" id="1726">
                                                             <rect key="frame" x="254" y="16" width="25" height="25"/>
@@ -762,7 +762,7 @@ to add them as DOS drives.</string>
                                                                 <outlet property="nextKeyView" destination="1623" id="2098"/>
                                                             </connections>
                                                         </button>
-                                                        <textField verticalHuggingPriority="750" id="2100" customClass="BXIndentedHelpTextLabel">
+                                                        <textField verticalHuggingPriority="750" id="2100">
                                                             <rect key="frame" x="21" y="47" width="256" height="29"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                                             <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" id="2101">

--- a/Resources/Base.lproj/InspectorJoystickItem.xib
+++ b/Resources/Base.lproj/InspectorJoystickItem.xib
@@ -41,7 +41,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                     <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="string" keyPath="themeKey" value="BXInspectorListHelpTextTheme"/>
+                        <userDefinedRuntimeAttribute type="string" keyPath="themeKey" value="BXInspectorListTheme"/>
                     </userDefinedRuntimeAttributes>
                     <connections>
                         <binding destination="-2" name="value" keyPath="representedObject.localizedInformativeText" id="27"/>

--- a/Resources/Base.lproj/Preferences.xib
+++ b/Resources/Base.lproj/Preferences.xib
@@ -54,7 +54,7 @@
                                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Keep my DOS games in:" id="141">
                                                         <font key="font" metaFont="system"/>
-                                                        <color key="textColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
                                                 </textField>


### PR DESCRIPTION
Some labels used hard-coded color values, making them difficult to read in dark mode:

<img width="342" src="https://user-images.githubusercontent.com/4042863/87558606-96d4cf80-c6b9-11ea-9706-629776c996f3.png">
<img width="644" src="https://user-images.githubusercontent.com/4042863/87558595-93414880-c6b9-11ea-8928-f82a0a0b635e.png">
