### PR TITLE
Skip installer step in release builds

### DIFF
--- a/Boxer/BXImportSession.m
+++ b/Boxer/BXImportSession.m
@@ -192,8 +192,12 @@
         //choose which installer to use.
 		if (!scan.isAlreadyInstalled && self.installerURLs.count)
         {
+            #ifdef BOXER_DEBUG
 			self.importStage = BXImportSessionWaitingForInstaller;
             [NSApp requestUserAttention: NSInformationalRequest];
+			#else
+			[self skipInstaller];
+            #endif
         }
         //Otherwise, we'll get on with finalizing the import directly.
 		else


### PR DESCRIPTION
As the importer currently displays a “Session is not ready” error when launching an installer, it’s probably less confusing to just skip this step in release builds for now.