### PR TITLE
Fix mapping to have extensions be authoritative, not UTIs

### DIFF
--- a/Boxer/BXDrive.m
+++ b/Boxer/BXDrive.m
@@ -64,29 +64,56 @@
 + (BXDriveType) preferredTypeForContentsOfURL: (NSURL *)URL
 {
 	NSWorkspace *workspace = [NSWorkspace sharedWorkspace];
-    
-    //First check if the file's UTI corresponds to one of our known types.
+
+    //FIRST: Check extension-based type detection (authoritative for Boxer folders)
+    NSString *extension = URL.pathExtension.lowercaseString;
+    if (extension.length > 0)
+    {
+        NSString *extensionType = [BXFileTypes extensionToTypeMapping][extension];
+        if (extensionType)
+        {
+            // Map UTI types to drive types
+            if ([extensionType isEqualToString:BXCDROMFolderType] ||
+                [extensionType isEqualToString:BXCDROMImageBundleType] ||
+                [extensionType isEqualToString:BXCuesheetImageType] ||
+                [extensionType isEqualToString:BXISOImageType] ||
+                [extensionType isEqualToString:BXCDRImageType])
+                return BXDriveCDROM;
+
+            if ([extensionType isEqualToString:BXFloppyFolderType] ||
+                [extensionType isEqualToString:BXRawFloppyImageType] ||
+                [extensionType isEqualToString:BXVirtualPCImageType] ||
+                [extensionType isEqualToString:BXNDIFImageType] ||
+                [extensionType isEqualToString:BXUDIFImageType])
+                return BXDriveFloppyDisk;
+
+            if ([extensionType isEqualToString:BXHardDiskFolderType])
+                return BXDriveHardDisk;
+        }
+    }
+
+    //FALLBACK: Check if the file's UTI corresponds to one of our known types.
     //This catches disk images and Boxer mountable folders (.cdrom, .harddisk etc.)
     if ([URL matchingFileType: [BXFileTypes cdVolumeTypes]] != nil)
         return BXDriveCDROM;
-    
+
     if ([URL matchingFileType: [BXFileTypes floppyVolumeTypes]] != nil)
         return BXDriveFloppyDisk;
-    
+
     if ([URL matchingFileType: [BXFileTypes hddVolumeTypes]] != nil)
         return BXDriveHardDisk;
-    
+
     //Failing that, check the volume type of the underlying filesystem at that location.
     NSString *volumeType = [workspace typeOfVolumeAtURL: URL];
-	
+
 	//Mount locations on data or audio CD volumes as CD-ROM drives.
 	if ([volumeType isEqualToString: ADBDataCDVolumeType] || [volumeType isEqualToString: ADBAudioCDVolumeType])
 		return BXDriveCDROM;
-    
+
 	//If the location is on a FAT/FAT32 volume, check if it's floppy-sized.
 	if ([workspace isFloppyVolumeAtURL: URL])
         return BXDriveFloppyDisk;
-	
+
 	//In all other cases, fall back on a standard hard-disk mount.
 	return BXDriveHardDisk;
 }
@@ -113,8 +140,20 @@
 {
     //Dots in DOS volume labels are acceptable, but may be confused with file extensions which
     //we do want to remove. So, we strip off the extensions for our known image/folder types.
-    BOOL shouldStripExtension = ([URL matchingFileType: [self mountableTypesWithExtensions]] != nil);
-    
+    BOOL shouldStripExtension = NO;
+
+    // FIRST: Check if extension is in our mapping (authoritative)
+    NSString *extension = URL.pathExtension.lowercaseString;
+    if (extension.length > 0 && [BXFileTypes extensionToTypeMapping][extension])
+    {
+        shouldStripExtension = YES;
+    }
+    // FALLBACK: Check UTI
+    else if ([URL matchingFileType: [self mountableTypesWithExtensions]] != nil)
+    {
+        shouldStripExtension = YES;
+    }
+
     NSString *baseName = URL.lastPathComponent;
     if (shouldStripExtension)
         baseName = baseName.stringByDeletingPathExtension;
@@ -140,18 +179,63 @@
 {
     //If the URL represents a Boxer mountable folder or a disk image,
     //try to parse the drive letter from the name.
-    if ([URL matchingFileType: [self mountableTypesWithEmbeddedDriveLetters]] != nil)
+    BOOL isExtensionMatch = NO;
+    BOOL isUTIMatch = NO;
+
+    // FIRST: Try extension-based matching (authoritative)
+    NSString *extension = URL.pathExtension.lowercaseString;
+    if (extension.length > 0)
+    {
+        NSString *extensionType = [BXFileTypes extensionToTypeMapping][extension];
+        if (extensionType)
+        {
+            // Extension mapping is authoritative - if it's in our mapping, it's mountable
+            isExtensionMatch = YES;
+            NSLog(@"[BXDrive] preferredDriveLetterForContentsOfURL: %@ (matched by extension: .%@ → %@)",
+                  URL.lastPathComponent, extension, extensionType);
+        }
+    }
+
+    // FALLBACK: Try UTI-based matching
+    if (!isExtensionMatch)
+    {
+        NSSet *mountableTypes = [self mountableTypesWithEmbeddedDriveLetters];
+        NSString *matchedType = [URL matchingFileType: mountableTypes];
+        if (matchedType)
+        {
+            isUTIMatch = YES;
+            NSLog(@"[BXDrive] preferredDriveLetterForContentsOfURL: %@ (matched by UTI: %@)",
+                  URL.lastPathComponent, matchedType);
+        }
+    }
+
+    if (isExtensionMatch || isUTIMatch)
 	{
 		NSString *baseName          = URL.lastPathComponent.stringByDeletingPathExtension;
 		NSString *detectedLetter	= [baseName stringByMatching: @"^([a-xA-X])( .*)?$" capture: 1];
+        NSLog(@"[BXDrive]   baseName: '%@' → regex match: '%@'", baseName, detectedLetter ?: @"(no match)");
 		return detectedLetter;	//will be nil if no match was found
 	}
+    NSLog(@"[BXDrive]   Not a mountable type, returning nil");
 	return nil;
 }
 
 + (NSURL *) mountPointForContentsOfURL: (NSURL *)URL
 {
-    if ([URL conformsToFileType: BXCDROMImageBundleType])
+    // Check if this is a CD-ROM bundle - first by extension, then by UTI
+    BOOL isCDROMBundle = NO;
+
+    NSString *extension = URL.pathExtension.lowercaseString;
+    if ([extension isEqualToString:@"cdmedia"])
+    {
+        isCDROMBundle = YES;
+    }
+    else if ([URL conformsToFileType: BXCDROMImageBundleType])
+    {
+        isCDROMBundle = YES;
+    }
+
+    if (isCDROMBundle)
     {
         return [URL URLByAppendingPathComponent: @"tracks.cue" isDirectory: NO];
     }
@@ -244,20 +328,24 @@
 				self.mountPointURL = [self.class mountPointForContentsOfURL: _sourceURL];
                 self.hasAutodetectedMountPoint = YES;
             }
-			
+
 			//Automatically parse the drive letter, title and volume label from the name of the drive
 			if (!self.letter)
             {
-                self.letter = [self.class preferredDriveLetterForContentsOfURL: _sourceURL];
+                NSString *detectedLetter = [self.class preferredDriveLetterForContentsOfURL: _sourceURL];
+                NSLog(@"[BXDrive] Drive letter detection for '%@': %@",
+                      _sourceURL.lastPathComponent,
+                      detectedLetter ?: @"(none detected)");
+                self.letter = detectedLetter;
                 self.hasAutodetectedLetter = YES;
             }
-            
+
 			if (!self.volumeLabel)
             {
                 self.volumeLabel = [self.class preferredVolumeLabelForContentsOfURL: _sourceURL];
                 self.hasAutodetectedVolumeLabel = YES;
             }
-            
+
 			if (!self.title)
             {
                 self.title = [self.class preferredTitleForContentsOfURL: _sourceURL];

--- a/Boxer/BXFileTypes.h
+++ b/Boxer/BXFileTypes.h
@@ -69,6 +69,11 @@ extern NSString * const BXBatchProgramType;     //!< .bat
 /// want to override the handler for files with different extensions that conform to that UTI.
 @property (class, readonly, copy) NSDictionary<NSString*,NSString*> *fileHandlerOverrides;
 
+/// A dictionary of file extension->UTI pairs for Boxer-specific mountable types.
+/// This mapping takes precedence over macOS UTI detection, which may be unreliable
+/// when custom UTIs are not properly registered in the Launch Services database.
+@property (class, readonly, copy) NSDictionary<NSString*,NSString*> *extensionToTypeMapping;
+
 /// Returns a specific bundle identifier that we want to use to open the specified URL,
 /// or `nil` if OS X's default handler should be used. This uses `fileHandlerOverrides` to
 /// selectively override the default for files with particular extensions.

--- a/Boxer/BXFileTypes.m
+++ b/Boxer/BXFileTypes.m
@@ -197,6 +197,32 @@ NSString * const BXDOCFileType      = @"com.microsoft.word.doc";
     return handlers;
 }
 
++ (NSDictionary *) extensionToTypeMapping
+{
+    static NSDictionary *mapping;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        mapping = @{
+            // Folder types - these take precedence over macOS UTI detection
+            @"harddisk": BXHardDiskFolderType,
+            @"harddrive": BXHardDiskFolderType,
+            @"floppy": BXFloppyFolderType,
+            @"cdrom": BXCDROMFolderType,
+            @"cdmedia": BXCDROMImageBundleType,
+
+            // Image types
+            @"cue": BXCuesheetImageType,
+            @"inst": BXCuesheetImageType,
+            @"iso": BXISOImageType,
+            @"cdr": BXCDRImageType,
+            @"ima": BXRawFloppyImageType,
+            @"vfd": BXVirtualPCImageType,
+            @"gog": @"com.gog.gog-disk-image",
+        };
+    });
+    return mapping;
+}
+
 + (NSString *) bundleIdentifierForApplicationToOpenURL: (NSURL *)URL
 {
     NSURL *resolvedURL = URL.URLByResolvingSymlinksInPath;
@@ -474,11 +500,19 @@ NSString * const BXExecutableTypesErrorDomain = @"BXExecutableTypesErrorDomain";
 + (id <ADBFilesystemPathAccess, ADBFilesystemLogicalURLAccess>) filesystemWithContentsOfURL: (NSURL *)URL
                                                                                       error: (out NSError **)outError
 {
-    if ([URL conformsToFileType: BXCuesheetImageType])
+    // FIRST: Check by extension (authoritative for Boxer-specific types)
+    NSString *extension = URL.pathExtension.lowercaseString;
+    NSString *extensionType = [self extensionToTypeMapping][extension];
+
+    // CUE/INST files
+    if ([extension isEqualToString:@"cue"] || [extension isEqualToString:@"inst"] ||
+        [URL conformsToFileType: BXCuesheetImageType])
     {
         return [ADBBinCueImage imageWithContentsOfURL: URL error: outError];
     }
-    else if ([URL matchingFileType: [NSSet setWithObjects: BXISOImageType, BXCDRImageType, nil]])
+    // ISO/CDR files
+    else if ([extension isEqualToString:@"iso"] || [extension isEqualToString:@"cdr"] || [extension isEqualToString:@"gog"] ||
+             [URL matchingFileType: [NSSet setWithObjects: BXISOImageType, BXCDRImageType, nil]])
     {
         NSError *ourError = nil;
         ADBISOImage *isoImg = [ADBISOImage imageWithContentsOfURL: URL error: &ourError];
@@ -496,10 +530,13 @@ NSString * const BXExecutableTypesErrorDomain = @"BXExecutableTypesErrorDomain";
             return isoImg;
         }
     }
-    else if ([URL matchingFileType: [ADBMountableImage supportedImageTypes]])
+    // Other mountable image types (IMA, VFD, DMG, etc.)
+    else if ([extension isEqualToString:@"ima"] || [extension isEqualToString:@"vfd"] ||
+             [URL matchingFileType: [ADBMountableImage supportedImageTypes]])
     {
         return [ADBMountableImage imageWithContentsOfURL: URL error: outError];
     }
+    // Default: local filesystem
     else
     {
         return [ADBLocalFilesystem filesystemWithBaseURL: URL];

--- a/Boxer/BXGamebox.m
+++ b/Boxer/BXGamebox.m
@@ -477,13 +477,51 @@ NSString * const BXGameboxErrorDomain = @"BXGameboxErrorDomain";
                                                              includingPropertiesForKeys: @[NSURLTypeIdentifierKey]
                                                                                 options: options
                                                                            errorHandler: NULL];
-    
+
+    NSLog(@"[BXGamebox] Scanning for volumes in: %@", self.resourceURL.lastPathComponent);
+    // NSLog(@"[BXGamebox] Looking for file types: %@", fileTypes);
+
     NSMutableArray *matches = [NSMutableArray arrayWithCapacity: 10];
     for (NSURL *URL in enumerator)
     {
-        if ([URL matchingFileType: fileTypes] != nil)
+        NSString *matchedType = nil;
+
+        // FIRST: Try extension-based matching (authoritative)
+        NSString *extension = URL.pathExtension.lowercaseString;
+        if (extension.length > 0)
+        {
+            NSString *extensionType = [BXFileTypes extensionToTypeMapping][extension];
+            if (extensionType && [fileTypes containsObject:extensionType])
+            {
+                matchedType = extensionType;
+                NSLog(@"[BXGamebox] ✓ Matched by extension: %@ (.%@ → %@)",
+                      URL.lastPathComponent, extension, matchedType);
+            }
+        }
+
+        // FALLBACK: Try UTI-based matching
+        if (!matchedType)
+        {
+            matchedType = [URL matchingFileType: fileTypes];
+            if (matchedType)
+            {
+                NSLog(@"[BXGamebox] ✓ Matched by UTI: %@ (type: %@)",
+                      URL.lastPathComponent, matchedType);
+            }
+        }
+
+        // Add to results or log skip reason
+        if (matchedType != nil)
+        {
             [matches addObject: URL];
+        }
+        else
+        {
+            // NSLog(@"[BXGamebox] ✗ Skipped: %@ (UTI: %@, extension: %@)",
+            //      URL.lastPathComponent, URL.typeIdentifier ?: @"(null)", URL.pathExtension ?: @"(none)");
+        }
     }
+    NSLog(@"[BXGamebox] Found %lu matching volume(s)", (unsigned long)matches.count);
     return matches;
 }
 
@@ -504,32 +542,49 @@ NSString * const BXGameboxErrorDomain = @"BXGameboxErrorDomain";
 
 - (NSArray *) bundledDrives
 {
+    NSLog(@"[BXGamebox] === Building bundled drives list ===");
+
     NSMutableArray *bundledVolumes = [NSMutableArray arrayWithCapacity: 10];
     [bundledVolumes addObjectsFromArray: self.floppyVolumeURLs];
     [bundledVolumes addObjectsFromArray: self.hddVolumeURLs];
     [bundledVolumes addObjectsFromArray: self.cdVolumeURLs];
-    
+
+    NSLog(@"[BXGamebox] Total bundled volume URLs found: %lu", (unsigned long)bundledVolumes.count);
+
     BOOL hasProperDriveC = NO;
     NSMutableArray *drives = [NSMutableArray arrayWithCapacity: bundledVolumes.count];
-    
+
     for (NSURL *volumeURL in bundledVolumes)
     {
         BXDrive *drive = [BXDrive driveWithContentsOfURL: volumeURL letter: nil type: BXDriveAutodetect];
+        NSLog(@"[BXGamebox] Created drive from %@: letter=%@, type=%ld, volumeLabel=%@",
+              volumeURL.lastPathComponent,
+              drive.letter ?: @"(none)",
+              (long)drive.type,
+              drive.volumeLabel ?: @"(none)");
         [drives addObject: drive];
-        
+
         if ([drive.letter isEqualToString: @"C"])
+        {
+            NSLog(@"[BXGamebox] → Found explicit C drive!");
             hasProperDriveC = YES;
+        }
     }
-    
+
     //If we don't contain an explicit drive C, that means we're an old-style gamebox:
     //In this case, use the base folder of the gamebox itself as drive C.
     if (!hasProperDriveC)
     {
+        NSLog(@"[BXGamebox] No explicit C drive found, using gamebox root as C:");
         BXDrive *drive = [BXDrive driveWithContentsOfURL: self.resourceURL
                                                   letter: @"C"
                                                     type: BXDriveHardDisk];
-        
+        NSLog(@"[BXGamebox] → Created fallback C drive from %@", self.resourceURL.lastPathComponent);
         [drives addObject: drive];
+    }
+    else
+    {
+        NSLog(@"[BXGamebox] Using explicit C drive from .harddisk folder");
     }
     
     //Sort the drives first by letter and then by filename.


### PR DESCRIPTION
In recent MacOS UTIs have become less reliable and Boxer has been affected by this. Auto-detection of named folders fails because MacOS fails to register all the associations and also when multiple ones may exist in a given system.

This path adds explicit extension mapping to the existing UTI one so it takes precedence. Tested with all extension kinds and working. This indirectly fixes the demo games included which were failing because of this.

This was mentioned in ticket #69 