### PR TITLE
Fix Cmd+F4 disc cycling shortcut

### DIFF
--- a/Boxer/BXSession+BXUIControls.h
+++ b/Boxer/BXSession+BXUIControls.h
@@ -159,6 +159,9 @@ typedef NS_ENUM(NSInteger, BXPlaybackMode) {
 - (IBAction) mountNextDrivesInQueues: (id)sender;
 - (IBAction) mountPreviousDrivesInQueues: (id)sender;
 
+/// Cycle all mounted drives to their next queued images. Triggered by Cmd+F4 keyboard shortcut.
+- (IBAction) cycleMountedDiscsForward: (id)sender;
+
 /// Whether we have any drive queues that can be cycled. Used for UI bindings.
 - (BOOL) canCycleDrivesInQueues;
 

--- a/Boxer/BXSession+BXUIControls.m
+++ b/Boxer/BXSession+BXUIControls.m
@@ -1087,6 +1087,36 @@
     [self _mountQueuedSiblingsAtOffset: -1];
 }
 
+- (IBAction) cycleMountedDiscsForward: (id)sender
+{
+    //Cycle through each mounted drive's queued images, showing bezel notifications for each change.
+    //This is triggered by Cmd+F4 in the keyboard input handler.
+    for (BXDrive *currentDrive in self.mountedDrives)
+    {
+        BXDrive *siblingDrive = [self siblingOfQueuedDrive: currentDrive atOffset: 1];
+        if (siblingDrive && ![siblingDrive isEqual: currentDrive])
+        {
+            NSError *mountError = nil;
+            BXDrive *mountedDrive = [self mountDrive: siblingDrive
+                                            ifExists: BXDriveReplace
+                                             options: BXDefaultDriveMountOptions
+                                               error: &mountError];
+
+            if (!mountedDrive && mountError)
+            {
+                [self presentError: mountError
+                    modalForWindow: self.windowForDriveSheet
+                          delegate: nil
+                didPresentSelector: NULL
+                       contextInfo: NULL];
+
+                //Don't continue mounting if we encounter a problem
+                break;
+            }
+        }
+    }
+}
+
 + (NSSet *) keyPathsForValuesAffectingCanCycleDrivesInQueues
 {
     return [NSSet setWithObject: @"drives"];

--- a/Boxer/DOS window/BXInputController+BXKeyboardInput.m
+++ b/Boxer/DOS window/BXInputController+BXKeyboardInput.m
@@ -68,6 +68,14 @@
 
 - (void) keyDown: (NSEvent *)theEvent
 {
+	//Special handling for Cmd+F4 to cycle through mounted disc images
+	if ((theEvent.modifierFlags & NSEventModifierFlagCommand) == NSEventModifierFlagCommand &&
+		theEvent.keyCode == kVK_F4)
+	{
+		[self cycleMountedDiscsForward: self];
+		return;
+	}
+
 	//If the keypress was command-modified, don't pass it on to the emulator as it indicates
 	//a failed key equivalent.
 	//(This is consistent with how other OS X apps with textinput handle Cmd-keypresses.)
@@ -230,6 +238,10 @@
 - (IBAction) sendColon:         (id)sender { [self.representedObject.emulator handlePastedString: @":" asCommand: NO]; }
 - (IBAction) sendDash:          (id)sender { [self.representedObject.emulator handlePastedString: @"-" asCommand: NO]; }
 
+- (IBAction) cycleMountedDiscsForward: (id)sender
+{
+	[self.representedObject cycleMountedDiscsForward: sender];
+}
 
 - (void) type: (NSString *)message
 {


### PR DESCRIPTION
Pressing Cmd+F4 now correctly cycles around all mounted drives to their next queued disc image(s) with automatic bezel notifications showing the disc changes.

To mount multiple disk images place them in the root directory with the format:
{LETTER} {LABEL}.{EXTENSION}

Images for a drive letter will be mounted alphabetically.

A command line like:
imgmount a .\floppy\PROG32.IMA .\floppy\DATA1.IMA -t floppy

Becomes two files in the gamebox root names:
A 1PROG32.IMA
A 2DATA1.IMA

Shortcut cmd-F4 (or cmd-fn-F4) will cycle and
provide visual input as well as update the volume
inspector.

<img width="804" height="684" alt="image" src="https://github.com/user-attachments/assets/2f70d8a6-9e41-425f-9bd3-d5ce6516c290" />

<img width="342" height="549" alt="image" src="https://github.com/user-attachments/assets/6d090119-931e-4ad2-86a8-8b914a44d10f" />
