### PR TITLE
ADBBinCueImage: reject CUE resources outside the base folder

### DIFF
--- a/Boxer/BXDriveBundleImport.m
+++ b/Boxer/BXDriveBundleImport.m
@@ -126,15 +126,18 @@ NSString * const BXDriveBundleErrorDomain = @"BXDriveBundleErrorDomain";
 	if (self.isCancelled) return;
     
     //Work out what to do with the related file paths we've parsed from the cue file
-    NSURL *baseURL = sourceURL.URLByDeletingLastPathComponent;
     NSMutableDictionary *revisedPaths = [NSMutableDictionary dictionaryWithCapacity: numRelatedPaths];
     
     for (NSString *fromPath in relatedPaths)
     {
-        //Rewrite Windows-style paths
-        NSString *sanitisedFromPath = [fromPath stringByReplacingOccurrencesOfString: @"\\" withString: @"/"];
+        NSError *pathError = nil;
+        NSURL *fromURL      = [ADBBinCueImage resourceURLForRawPath: fromPath inCueAtURL: sourceURL error: &pathError];
+        if (!fromURL)
+        {
+            self.error = pathError;
+            return;
+        }
         
-        NSURL *fromURL      = [baseURL URLByAppendingPathComponent: sanitisedFromPath];
         NSString *fromName	= fromURL.lastPathComponent;
         NSURL *toURL        = [destinationURL URLByAppendingPathComponent: fromName];
         

--- a/Other Sources/ADBToolkit/ADBBinCueImage.h
+++ b/Other Sources/ADBToolkit/ADBBinCueImage.h
@@ -38,7 +38,12 @@ NS_ASSUME_NONNULL_BEGIN
     
 /// Returns an array of the track files specified in the specified CUE,
 /// as absolute OS X filesystem URLs resolved relative to the CUE's location.
+/// Returns @c nil and populates @c outError if any resource resolves outside the CUE's folder.
 + (nullable NSArray<NSURL*> *) resourceURLsInCueAtURL: (NSURL *)cueURL error: (out NSError **)outError;
+
+/// Returns a track file URL resolved relative to the specified CUE file.
+/// Returns @c nil and populates @c outError if the resource resolves outside the CUE's folder.
++ (nullable NSURL *) resourceURLForRawPath: (NSString *)rawPath inCueAtURL: (NSURL *)cueURL error: (out NSError **)outError;
 
 /// Returns the location of the binary image for the specified CUE file,
 /// as an absolute OS X filesystem URL resolved relative to the CUE's location.

--- a/Other Sources/ADBToolkit/ADBBinCueImage.m
+++ b/Other Sources/ADBToolkit/ADBBinCueImage.m
@@ -41,6 +41,26 @@ NSString * const ADBCueFileDescriptorSyntax = @"FILE\\s+(?:\"(.+)\"|(\\S+))\\s+[
 /// This is used as a sanity check by +isCueAtPath: to avoid scanning large files unnecessarily.
 #define ADBCueMaxFileSize 10240
 
+static BOOL ADBURLIsInDirectory(NSURL *URL, NSURL *directoryURL)
+{
+    NSString *path = URL.URLByStandardizingPath.URLByResolvingSymlinksInPath.path;
+    NSString *directoryPath = directoryURL.URLByStandardizingPath.URLByResolvingSymlinksInPath.path;
+
+    return [path isEqualToString: directoryPath] || [path hasPrefix: [directoryPath stringByAppendingString: @"/"]];
+}
+
+static NSError *ADBCueResourcePathError(NSURL *cueURL, NSString *rawPath)
+{
+    NSString *description = [NSString stringWithFormat: @"The CUE file “%@” refers to a resource outside its folder.", cueURL.lastPathComponent];
+    NSString *failureReason = [NSString stringWithFormat: @"The resource path “%@” does not resolve inside the CUE file's folder.", rawPath];
+
+    return [NSError errorWithDomain: NSCocoaErrorDomain
+                               code: NSFileReadInvalidFileNameError
+                           userInfo: @{ NSLocalizedDescriptionKey: description,
+                                        NSLocalizedFailureReasonErrorKey: failureReason,
+                                        NSURLErrorKey: cueURL }];
+}
+
 
 @implementation ADBBinCueImage
 
@@ -70,6 +90,28 @@ NSString * const ADBCueFileDescriptorSyntax = @"FILE\\s+(?:\"(.+)\"|(\\S+))\\s+[
 	return paths;
 }
 
++ (NSURL *) resourceURLForRawPath: (NSString *)rawPath inCueAtURL: (NSURL *)cueURL error: (out NSError **)outError
+{
+    NSURL *baseURL = cueURL.URLByDeletingLastPathComponent.URLByStandardizingPath;
+
+    //Rewrite Windows-style paths
+    NSString *normalizedPath = [rawPath stringByReplacingOccurrencesOfString: @"\\" withString: @"/"];
+
+    //Form an absolute path with all ../ components resolved.
+    NSURL *resourceURL = [baseURL URLByAppendingPathComponent: normalizedPath].URLByStandardizingPath;
+
+    if (!ADBURLIsInDirectory(resourceURL, baseURL))
+    {
+        if (outError)
+        {
+            *outError = ADBCueResourcePathError(cueURL, rawPath);
+        }
+        return nil;
+    }
+
+    return resourceURL;
+}
+
 + (NSArray *) resourceURLsInCueAtURL: (NSURL *)cueURL error: (out NSError **)outError
 {
     NSString *cueContents = [[NSString alloc] initWithContentsOfURL: cueURL
@@ -81,20 +123,28 @@ NSString * const ADBCueFileDescriptorSyntax = @"FILE\\s+(?:\"(.+)\"|(\\S+))\\s+[
     
     NSArray *rawPaths = [self rawPathsInCueContents: cueContents];
     
-    //The URL relative to which we will resolve the paths in the CUE
-    NSURL *baseURL = cueURL.URLByDeletingLastPathComponent;
-    
     NSMutableArray *resolvedURLs = [NSMutableArray arrayWithCapacity: rawPaths.count];
+    NSError *resourceError = nil;
     for (NSString *rawPath in rawPaths)
     @autoreleasepool {
-        //Rewrite Windows-style paths
-        NSString *normalizedPath = [rawPath stringByReplacingOccurrencesOfString: @"\\" withString: @"/"];
-        
-        //Form an absolute path with all ../ components resolved.
-        NSURL *resourceURL = [baseURL URLByAppendingPathComponent: normalizedPath].URLByStandardizingPath;
+        NSURL *resourceURL = [self resourceURLForRawPath: rawPath inCueAtURL: cueURL error: &resourceError];
+        if (!resourceURL)
+        {
+            break;
+        }
         
         [resolvedURLs addObject: resourceURL];
     }
+
+    if (resourceError)
+    {
+        if (outError)
+        {
+            *outError = resourceError;
+        }
+        return nil;
+    }
+
     return resolvedURLs;
 }
 


### PR DESCRIPTION
Thanks for continuing to maintain Boxer. This is a small CUE input-validation fix.

Previously, a CUE `FILE` entry using `../` segments (or a symlink inside the CUE's folder pointing elsewhere) could resolve to a path outside that folder, so Boxer would queue an out-of-folder file for copying. CUE sheets are untrusted input, so this adds containment.

CUE `FILE` entries now resolve through a shared helper that standardizes each path relative to the CUE file, resolves symlinks, and rejects resources that land outside the CUE file's folder. Bundle import uses the same resolver, so invalid entries fail before any file is queued for copying.

One scope note: the same resolver is used by CUE resource enumeration for image mounting. A CUE with any out-of-folder resource now fails to resolve as a whole, instead of silently resolving that outside path. I chose fail-closed here, but can make the mount path best-effort if you prefer.

## Test plan

- Built `xcodebuild -workspace Boxer.xcworkspace -scheme "Boxer CI" -configuration Release build`
- Verified `../outside.bin` is rejected with `NSFileReadInvalidFileNameError`
- Verified a symlink to an outside file is rejected with `NSFileReadInvalidFileNameError`
- Verified `tracks/inside.bin` still resolves inside the CUE folder

*Drafted with AI assistance (OpenAI Codex, gpt-5; Claude Code, claude-opus-4-7). Reviewed by @downtempo.*